### PR TITLE
Disable sites/*/files for scanning

### DIFF
--- a/core/.env.example
+++ b/core/.env.example
@@ -63,4 +63,4 @@ DRUPAL_NIGHTWATCH_OUTPUT=reports/nightwatch
 
 # Filter directories to look for tests. This uses minimatch syntax.
 # Separate folders with a comma.
-DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES=node_modules/,vendor/,.git/
+DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES=node_modules/,vendor/,.git/,sites/*/files


### PR DESCRIPTION
When looking at a testrun with @mixologic we realized that the glob right now scans the entire sites/*/files directory. On the testbot this folder is created by the webuser and as such is not accessible.

Let's avoid scanning into that folder in the first place.